### PR TITLE
Fix PhenoAge final-transform constants (~2 year error)

### DIFF
--- a/phenoage.js
+++ b/phenoage.js
@@ -120,7 +120,7 @@ function calculateResult() {
   console.log(mortalityScore);
   // As a 'fun' aside, calculate the risk of death over the next 12 months...
   riskOfDeath = 1-Math.exp(-Math.exp(rollingTotal)*(Math.exp(gamma*12)-1)/gamma);
-  phenoAge = 141.50225+Math.log(-0.00553*Math.log(1-mortalityScore))/0.090165;
+  phenoAge = 141.50225+Math.log(-0.0055305*Math.log(1-mortalityScore))/0.09165;
   console.log(phenoAge);
 
   // Display the result


### PR DESCRIPTION
The two constants used to convert the mortality score into phenotypic age had transposed/rounded digits compared to the original Levine 2018 values. This shifted the calculated PhenoAge by approximately **2 years**.

## The bug

```js
// Before (incorrect):
phenoAge = 141.50225 + Math.log(-0.00553 * Math.log(1-mortalityScore)) / 0.090165;

// After (correct):
phenoAge = 141.50225 + Math.log(-0.0055305 * Math.log(1-mortalityScore)) / 0.09165;
```

Two issues:
1. `-0.00553` should be `-0.0055305` (missing trailing digits)
2. `0.090165` should be `0.09165` (transposition of the last two digits)

## Verification

The corrected values match:
- The canonical **BioAge R package** ([dayoonkwon/BioAge](https://github.com/dayoonkwon/BioAge), `phenoage_calc.R` line: `dat$phenoage0 = ((log(-.0055305 * (log(1 - m_orig))) / .09165) + 141.50225)`)
- The **Cramer/Lustgarten PhenoAge spreadsheet** ([DNAmPhenoAge_gen.xls](https://michaellustgarten.com/wp-content/uploads/2021/10/3ba41-dnamphenoage_gen-1.xls))
- The Levine 2018 paper's Gompertz model parameters

### Example (from the Lustgarten spreadsheet)

Inputs: albumin=5.0 g/dL, creatinine=0.85 mg/dL, glucose=80 mg/dL, CRP=0.15 mg/L, lymphocyte=40%, MCV=88 fL, RDW=12%, ALP=45 U/L, WBC=4.2, age=47

| | Linear combination | Mortality score | PhenoAge |
|---|---|---|---|
| Spreadsheet | -10.4638 | 0.005615 | **28.28** |
| Old code | -10.4638 | 0.005615 | **26.41** |
| Fixed code | -10.4638 | 0.005615 | **28.28** ✓ |

Note: the intermediate values (linear combination and mortality score) were already correct — only the final transform step was affected.

## Note on biolearn

The Python [biolearn](https://github.com/bio-learn/biolearn) package (`hematology.py`) appears to have the same bug: `cs = [141.50225, -0.00553, 0.090165]`. I'll file a separate issue there.