### PR TITLE
Add Longevity World Cup as related tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,3 +34,5 @@ For privacy reasons, these calculators will never store your data. You can only 
 # Other tools for biomarker calculation
 
 For more detailed analysis of biomarkers using Python, try [Biolearn](https://bio-learn.github.io/)!
+
+For another browser-based PhenoAge calculator derived from this project, with additional validation checks and a public biological-age competition leaderboard, see [Longevity World Cup](https://www.longevityworldcup.com/onboarding/pheno-age.html).


### PR DESCRIPTION
Adds a concise link to Longevity World Cup under the existing related-tools section.\n\nWhy this fits:\n- The LWC PhenoAge calculator is browser-based and derived from this project.\n- It adds validation checks around the calculator flow.\n- It connects the calculator to a public biological-age competition leaderboard.\n\nNo tests were run; this is a README-only documentation change.